### PR TITLE
[feat] 로드맵 도메인 엔티티 구현

### DIFF
--- a/back/src/main/java/com/back/domain/job/job/entity/Job.java
+++ b/back/src/main/java/com/back/domain/job/job/entity/Job.java
@@ -1,0 +1,34 @@
+package com.back.domain.job.job.entity;
+
+import com.back.global.jpa.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Entity
+@Table(name = "job")
+@Getter @Setter
+@NoArgsConstructor
+public class Job extends BaseEntity {
+    @Column(name = "name", nullable = false, unique = true)
+    private String name;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @OneToMany(mappedBy = "job", cascade = CascadeType.ALL)
+    private List<JobAlias> aliases;
+
+    public Job(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
+
+    public void addAlias(JobAlias alias) {
+        aliases.add(alias);
+        alias.setJob(this);
+    }
+}

--- a/back/src/main/java/com/back/domain/job/job/entity/JobAlias.java
+++ b/back/src/main/java/com/back/domain/job/job/entity/JobAlias.java
@@ -1,0 +1,25 @@
+package com.back.domain.job.job.entity;
+
+import com.back.global.jpa.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "job_alias")
+@Getter @Setter
+@NoArgsConstructor
+public class JobAlias extends BaseEntity {
+    @Column(name = "name", nullable = false)
+    private String name; // 사용자가 입력한 직군 이름
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "job_id")
+    private Job job; // 표준 Job 연결 (NULL이면 pending 상태)
+
+    public JobAlias(String name) {
+        this.name = name;
+        this.job = null; // 기본적으로 연결된 Job이 없음 (pending 상태)
+    }
+}

--- a/back/src/main/java/com/back/domain/roadmap/roadmap/entity/JobRoadmap.java
+++ b/back/src/main/java/com/back/domain/roadmap/roadmap/entity/JobRoadmap.java
@@ -1,0 +1,25 @@
+package com.back.domain.roadmap.roadmap.entity;
+
+import com.back.global.jpa.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "job_roadmap")
+@Getter @Setter
+@NoArgsConstructor
+public class JobRoadmap extends BaseEntity {
+    @Column(name = "job_id", nullable = false)
+    private Long jobId; // Job FK
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "root_node_id", nullable = false)
+    private RoadmapNode rootNode;
+
+    public JobRoadmap(Long jobId, RoadmapNode rootNode) {
+        this.jobId = jobId;
+        this.rootNode = rootNode;
+    }
+}

--- a/back/src/main/java/com/back/domain/roadmap/roadmap/entity/JobRoadmapNodeStat.java
+++ b/back/src/main/java/com/back/domain/roadmap/roadmap/entity/JobRoadmapNodeStat.java
@@ -1,0 +1,23 @@
+package com.back.domain.roadmap.roadmap.entity;
+
+import com.back.global.jpa.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "job_roadmap_node_stat")
+@Getter @Setter
+@NoArgsConstructor
+public class JobRoadmapNodeStat extends BaseEntity {
+    @Column(name = "step_order")
+    private Integer stepOrder;
+
+    @Column(name = "weight", nullable = false)
+    private Double weight = 0.0;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "node_id", nullable = false)
+    private RoadmapNode node;
+}

--- a/back/src/main/java/com/back/domain/roadmap/roadmap/entity/MentorRoadmap.java
+++ b/back/src/main/java/com/back/domain/roadmap/roadmap/entity/MentorRoadmap.java
@@ -1,0 +1,33 @@
+package com.back.domain.roadmap.roadmap.entity;
+
+import com.back.global.jpa.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "mentor_roadmap")
+@Getter @Setter
+@NoArgsConstructor
+public class MentorRoadmap extends BaseEntity {
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "mentor_id", nullable = false)
+    private Long mentorId; // Mentor 엔티티 FK
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "root_node_id", nullable = false)
+    private RoadmapNode rootNode;
+
+    public MentorRoadmap(Long mentorId, String title, String description, RoadmapNode rootNode) {
+        this.mentorId = mentorId;
+        this.title = title;
+        this.description = description;
+        this.rootNode = rootNode;
+    }
+}

--- a/back/src/main/java/com/back/domain/roadmap/roadmap/entity/RoadmapNode.java
+++ b/back/src/main/java/com/back/domain/roadmap/roadmap/entity/RoadmapNode.java
@@ -1,0 +1,47 @@
+package com.back.domain.roadmap.roadmap.entity;
+
+import com.back.domain.roadmap.task.entity.Task;
+import com.back.global.jpa.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Entity
+@Table(name = "roadmap_node")
+@Getter @Setter
+@NoArgsConstructor
+public class RoadmapNode extends BaseEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private RoadmapNode parent;
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<RoadmapNode> children;
+
+    @Column(name = "step_order", nullable = false)
+    private int stepOrder = 0;
+
+    @Column(name = "raw_task_name")
+    private String rawTaskName; // 원본 Task 입력값
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "task_id")
+    private Task task; // 표준 Task
+
+    public RoadmapNode(String rawTaskName, String description, Task task) {
+        this.rawTaskName = rawTaskName;
+        this.description = description;
+        this.task = task;
+    }
+
+    public void addChild(RoadmapNode child) {
+        children.add(child);
+        child.setParent(this);
+    }
+}

--- a/back/src/main/java/com/back/domain/roadmap/task/entity/Task.java
+++ b/back/src/main/java/com/back/domain/roadmap/task/entity/Task.java
@@ -1,0 +1,30 @@
+package com.back.domain.roadmap.task.entity;
+
+import com.back.global.jpa.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Entity
+@Table(name = "task")
+@Getter @Setter
+@NoArgsConstructor
+public class Task extends BaseEntity {
+    @Column(name = "name", nullable = false, unique = true)
+    private String name;
+
+    @OneToMany(mappedBy = "task", cascade = CascadeType.ALL)
+    private List<TaskAlias> aliases;
+
+    public Task(String name) {
+        this.name = name;
+    }
+
+    public void addAlias(TaskAlias alias) {
+        aliases.add(alias);
+        alias.setTask(this);
+    }
+}

--- a/back/src/main/java/com/back/domain/roadmap/task/entity/TaskAlias.java
+++ b/back/src/main/java/com/back/domain/roadmap/task/entity/TaskAlias.java
@@ -1,0 +1,25 @@
+package com.back.domain.roadmap.task.entity;
+
+import com.back.global.jpa.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "task_alias")
+@Getter @Setter
+@NoArgsConstructor
+public class TaskAlias extends BaseEntity {
+    @Column(name = "name", nullable = false)
+    private String name; // 사용자가 입력한 Task 이름
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "task_id")
+    private Task task; // 표준 Task 연결 (NULL이면 pending 상태)
+
+    public TaskAlias(String name) {
+        this.name = name;
+        this.task = null; // 기본적으로 연결된 Task가 없음 (pending 상태)
+    }
+}


### PR DESCRIPTION
## 📢 기능 설명
로드맵 도메인과 관련된 엔티티 구현

구현된 엔티티 목록
- Job: 표준 직업 정보
- JobAlias: 직업 별칭
- Task: 표준 Task 정보
- TaskAlias: Task 별칭
- RoadmapNode: 로드맵 노드
- MentorRoadmap: 멘토 로드맵 루트 정보와 메타 데이터
- JobRoadmap: 직업 로드맵 루트 정보와 메타 데이터
- JobRoadmapNodeStat: 직업 로드맵 노드 통계(가중치) 정보

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #14 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?
