### PR TITLE
뉴스 댓글, 영상 테스트 클래스 예외 반환타입 수정

### DIFF
--- a/back/src/test/java/com/back/domain/file/service/VideoServiceTest.java
+++ b/back/src/test/java/com/back/domain/file/service/VideoServiceTest.java
@@ -21,6 +21,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 import java.util.function.Consumer;
 
@@ -103,7 +104,7 @@ class VideoServiceTest {
         try {
             videoService.getNewsByUuid(uuid);
         } catch (Exception e) {
-            assertThat(e).isInstanceOf(IllegalArgumentException.class);
+            assertThat(e).isInstanceOf(NoSuchElementException.class);
             assertThat(e.getMessage()).isEqualTo("존재하지 않는 비디오입니다.");
         }
     }

--- a/back/src/test/java/com/back/domain/news/comment/entity/NewsCommentTest.java
+++ b/back/src/test/java/com/back/domain/news/comment/entity/NewsCommentTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class PostCommentTest {
+class NewsCommentTest {
     @Test
     @DisplayName("사용자, 뉴스, 내용으로 댓글 객체 생성")
     void commentCreationTest() {

--- a/back/src/test/java/com/back/domain/news/comment/service/NewsCommentServiceTest.java
+++ b/back/src/test/java/com/back/domain/news/comment/service/NewsCommentServiceTest.java
@@ -14,8 +14,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.springframework.security.access.AccessDeniedException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,7 +26,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-class PostCommentServiceTest {
+class NewsCommentServiceTest {
 
     @Mock
     private CommentRepository commentRepository;
@@ -110,11 +112,12 @@ class PostCommentServiceTest {
         when(commentRepository.findById(nonExistentCommentId)).thenReturn(Optional.empty());
 
         // when & then
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+        NoSuchElementException exception = assertThrows(NoSuchElementException.class, () -> {
             commentService.updateComment(member, news, nonExistentCommentId, updatedContent);
         });
 
-        assertThat(exception.getMessage()).isEqualTo("Comment not found");
+
+        assertThat(exception.getMessage()).isEqualTo("Comment not found: " + nonExistentCommentId);
         verify(commentRepository, times(1)).findById(nonExistentCommentId);
     }
 
@@ -132,7 +135,7 @@ class PostCommentServiceTest {
         when(commentRepository.findById(commentId)).thenReturn(Optional.of(existingComment));
 
         // when & then
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+        AccessDeniedException exception = assertThrows(AccessDeniedException.class, () -> {
             commentService.updateComment(otherMember, news, commentId, updatedContent);
         });
 
@@ -193,11 +196,11 @@ class PostCommentServiceTest {
         when(commentRepository.findById(nonExistentCommentId)).thenReturn(Optional.empty());
 
         // when & then
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+        NoSuchElementException exception = assertThrows(NoSuchElementException.class, () -> {
             commentService.deleteComment(member, news, nonExistentCommentId);
         });
 
-        assertThat(exception.getMessage()).isEqualTo("Comment not found");
+        assertThat(exception.getMessage()).isEqualTo("Comment not found: " + nonExistentCommentId);
         verify(commentRepository, times(1)).findById(nonExistentCommentId);
         verify(commentRepository, never()).delete(any(Comment.class));
     }
@@ -215,7 +218,7 @@ class PostCommentServiceTest {
         when(commentRepository.findById(commentId)).thenReturn(Optional.of(existingComment));
 
         // when & then
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+        AccessDeniedException exception = assertThrows(AccessDeniedException.class, () -> {
             commentService.deleteComment(otherMember, news, commentId);
         });
 


### PR DESCRIPTION
## 📢 기능 설명

- VideoServiceTest의 테스트가 올바른 에러를 기대하도록 수정하였습니다.
- PostCommentTest, PostCommentServiceTest가 도메인에 관련된 클래스명을 갖도록 수정했습니다.

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #57 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?
